### PR TITLE
Updating Docs to work with new Column Resizing feature in SuperTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5793,9 +5793,9 @@
       }
     },
     "fixed-data-table-2": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-0.8.15.tgz",
-      "integrity": "sha512-t2XDXMX2hdd7lUuGhoFVFUOupXuUG0TDHWmR8ah5Qm70vEtT5z7Vjw/MsIwTNPTUQDYy3iTpEGQs+1RS133FUQ==",
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fixed-data-table-2/-/fixed-data-table-2-0.8.16.tgz",
+      "integrity": "sha512-GbHj+nyAUEOd5qudXBbbUtJPgQDgvykqSDaJSMQ4boC/z1ZA2d/XUj0I+xK2ha4j64kbjTjXNzZEGtFMb5wO/g==",
       "requires": {
         "create-react-class": "^15.5.2",
         "prop-types": "^15.5.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fdns-ui-react-docs",
   "description": "This is the documentation React app for the FDNS UI React Library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Centers for Disease Control and Prevention (http://github.com/CDCgov)",
   "license": "Apache-2.0",
   "repository": {
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "ajv": "^6.5.1",
-    "fdns-ui-react": "^0.5.8",
+    "fdns-ui-react": "0.5.8",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/docs/DocSuperTable.js
+++ b/src/docs/DocSuperTable.js
@@ -8,7 +8,11 @@ const data = messages.slice(0).splice(0,25);
 class DocSuperTable extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      headers: headers
+    };
     this.handleDetail = this.handleDetail.bind(this);
+    this.handleColumnResize = this.handleColumnResize.bind(this);
   }
 
   handleDetail(item) {
@@ -35,13 +39,22 @@ class DocSuperTable extends Component {
     return 226;
   }
 
+  // column resizing event for the table column
+  handleColumnResize(newColumnWidth, columnKey) {
+    headers[columnKey].width = newColumnWidth;
+    this.setState({
+      headers
+    })
+  }
+
   render() {
     const sampleComponent = (
-      <SuperTable data={data} 
-                  headers={headers} 
+      <SuperTable data={data}
+                  headers={this.state.headers}
                   onDetail={this.handleDetail}
                   getWidth={this.getWidth}
                   getHeight={this.getHeight}
+                  onColumnResize={this.handleColumnResize}
                   showErrorsAndWarnings={false}
                   ref="table" />
     );


### PR DESCRIPTION
This PR updates the SuperTable component to work properly with the customizable onColumnResize prop in the SuperTable that was updated in fdns-ui-react 0.5.7.

It also changes the package.json to use exactly the version it was last tested with (as opposed to "anything this version or greater") so it can be more easily evaluated when finding where a new version of fdns-ui-react breaks the docs.