### PR TITLE
Removing PORT from the npm start because it breaks on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-scripts": "^3.0.0"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",


### PR DESCRIPTION
It's also not necessary for the react-scripts start